### PR TITLE
Fix broken link in appendix_partij-indeling

### DIFF
--- a/content/blog/elections-2025/appendix_partij-indeling.md
+++ b/content/blog/elections-2025/appendix_partij-indeling.md
@@ -1,4 +1,4 @@
-De indeling van partijen langs het politieke spectrum is gebaseerd op het <a target="_blank" href="[https://tweedekamer2025.kieskompas.nl/nl/]">politieke landschap</a> gehanteerd door het Kieskompas.
+De indeling van partijen langs het politieke spectrum is gebaseerd op het <a target="_blank" href="https://tweedekamer2025.kieskompas.nl/nl/">politieke landschap</a> gehanteerd door het Kieskompas.
 
 ##### <a name="Categorisering van politieke partijen op ideologie"></a>Categorisering van politieke partijen op ideologie
 


### PR DESCRIPTION
Removes stray square brackets around the Kieskompas URL that broke link rendering.